### PR TITLE
fix regexp for entity.global.clojure

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -166,7 +166,7 @@
     'name': 'meta.expression.clojure'
     'patterns': [
       {
-        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+(.+?)(?=\\s)'
+        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+([\\w+|\\-+|\\.+]+)+\\s*'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'


### PR DESCRIPTION
Noticed syntax highlighting was off for the parentheses.  ex: (ns hello-world.core).  Is this an ok replacement?
