### PR TITLE
fix sexp regexp begin pattern

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -166,7 +166,7 @@
     'name': 'meta.expression.clojure'
     'patterns': [
       {
-        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+([\\w+|\\-+|\\.+]+)+\\s*'
+        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+(.+?)(?=\\s|\\))'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'


### PR DESCRIPTION
I think this will fix the issue when you have a single expression after a keyword:
 (ns hello-world) or (def apple) etc.. 
