### PR TITLE
grammar: Do not randomly sprinkle recursive includes

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -234,30 +234,15 @@
           {
             # there may be some metadata before an actual definition
             'include': '#metadata'
-            'patterns': [
-              {
-                'include': '$self'
-              }
-            ]
           }
           { # dynamic variables are rendered diferently
             'include': '#dynamic-variables'
-            'patterns': [
-              {
-                'include': '$self'
-              }
-            ]
           }
           {
             # recognizing a symbol as being defined here
             # copied and pasted from #symbol, screw it
             'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
             'name': 'entity.global.clojure'
-            'patterns': [
-              {
-                'include': '$self'
-              }
-            ]
           }
           {
             'include': '$self'
@@ -266,27 +251,12 @@
       }
       {
         'include': '#keyfn'
-        'patterns': [
-          {
-            'include': '$self'
-          }
-        ]
       }
       {
         'include': '#constants'
-        'patterns': [
-          {
-            'include': '$self'
-          }
-        ]
       }
       {
         'include': '#vector'
-        'patterns': [
-          {
-            'include': '$self'
-          }
-        ]
       }
       {
         'match': '(?<=\\()(.+?)(?=\\s|\\))'


### PR DESCRIPTION
It appears that https://github.com/atom/language-clojure/pull/13 introduce some changes to the grammar that caused unbounded (and unnecessary) meta recursion on most rules, greatly increasing the verbosity of the output HTML. Since all `include` subrules in the patterns dictionary already had `$self` included, this just added a rather silly loop to the grammar.

This fixes the noisy HTML output that was reported in https://twitter.com/swannodette/status/568516306648977409

cc @aroben 