### PR TITLE
Match many more Clojure numeric constants

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -79,7 +79,7 @@
         'match': '(true|false)'
         'name': 'constant.language.boolean.clojure'
       }
-           {
+      {
         'match': '(-?\\d+/\\d+)'
         'name': 'constant.numeric.ratio.clojure'
       }

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -79,25 +79,37 @@
         'match': '(true|false)'
         'name': 'constant.language.boolean.clojure'
       }
-      {
-        'match': '(\\d+/\\d+)'
+           {
+        'match': '(-?\\d+/\\d+)'
         'name': 'constant.numeric.ratio.clojure'
       }
       {
-        'match': '(\\d+r\\d+)'
+        'match': '(-?\\d+[rR][0-9a-zA-Z]+)'
         'name': 'constant.numeric.arbitrary-radix.clojure'
       }
       {
-        'match': '(0x\\d+)'
-        'name': 'constant.numeric.hexidecimal.clojure'
+        'match': '(-?0[xX][0-9a-fA-F]+)'
+        'name': 'constant.numeric.hexadecimal.clojure'
       }
       {
-        'match': '(0\\d+)'
+        'match': '(-?0\\d+)'
         'name': 'constant.numeric.octal.clojure'
       }
       {
-        'match': '(\\d+)'
-        'name': 'constant.numeric.decimal.clojure'
+        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
+        'name': 'constant.numeric.bigdecimal.clojure'
+      }
+      {
+        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?)'
+        'name': 'constant.numeric.double.clojure'
+      }
+      {
+        'match': '(-?\\d+N)'
+        'name': 'constant.numeric.bigint.clojure'
+      }
+      {
+        'match': '(-?\\d+)'
+        'name': 'constant.numeric.long.clojure'
       }
       { # separating the pattern for reuse
         'include': '#keyword'


### PR DESCRIPTION
I started this change because Clojure considers the leading - sign to be part of a numeric constant, so it should be highlighted in blue like the digits themselves. As I started learning how to edit the patterns, I realized that many other things (floating point numbers, exponents, BigInt and BigNum constants, hex digits and other arbitrary radix non-numeric digits) were not being properly matched. So my changes became much more extensive, and this now seems to properly match everything it should.

A sample file for testing can be found at http://deepsymmetry.org/media/example.clj (especially the last two lines). I was testing my changes on Lightshow with this file, and my locally modified copy of the grammar, http://deepsymmetry.org/media/clojure.cson

The Clojure documentation I was reviewing as I was discovering more missing numeric constant formats to match is the Primitives / Numbers section near the top left of http://clojure.org/cheatsheet (and I did some testing in a Clojure REPL to discover that some of the elements are case insensitive, like the exponent and radix markers, but others are not, like the BigNum and BigInt markers).

As this is my first time trying to edit one of these grammars, I welcome careful review and suggestions for improvement!