### PR TITLE
Fix weirdly highlighted s-expression as callee

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -273,6 +273,14 @@
       {
         'include': '#vector'
       }
+      { # hack to keep it from highlighting the first parenthesis of an
+        # s-expression if it's the callee. Looks unusual otherwise.
+        'match': '(?<=\\()\\((?!\\s|\\))'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
       {
         'match': '(?<=\\()(.+?)(?=\\s|\\))'
         'captures':


### PR DESCRIPTION
This is what's being fixed (third line):

![picture](http://s18.postimg.org/wwk7oouw9/Screenshot_from_2015_10_19_05_14_39.png)