### PR TITLE
Add begin and end captures for vectors

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -332,7 +332,13 @@
     'name': 'meta.var.clojure'
   'vector':
     'begin': '(\\[)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.vector.begin.clojure'
     'end': '(\\])'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.vector.end.clojure'
     'name': 'meta.vector.clojure'
     'patterns': [
       {


### PR DESCRIPTION
Ran into this when trying to de-emphasize section punctuation, nicely made feasible by [Parinfer](https://atom.io/packages/parinfer).