### PR TITLE
new rule for Parinfer

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -142,7 +142,7 @@
     'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.map.end.clojure.paren-trail'
+        'name': 'punctuation.section.map.end.trailing.clojure'
       '2':
         'name': 'punctuation.section.map.end.clojure'
     'name': 'meta.map.clojure'
@@ -161,7 +161,7 @@
         'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
         'endCaptures':
           '1':
-            'name': 'punctuation.section.metadata.map.end.clojure.paren-trail'
+            'name': 'punctuation.section.metadata.map.end.trailing.clojure'
           '2':
             'name': 'punctuation.section.metadata.map.end.clojure'
         'name': 'meta.metadata.map.clojure'
@@ -193,11 +193,11 @@
     'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+        'name': 'punctuation.section.expression.end.trailing.clojure'
       '2':
         'name': 'meta.after-expression.clojure'
       '3':
-        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+        'name': 'punctuation.section.expression.end.trailing.clojure'
       '4':
         'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.quoted-expression.clojure'
@@ -226,7 +226,7 @@
     'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.set.end.clojure.paren-trail'
+        'name': 'punctuation.section.set.end.trailing.clojure'
       '2':
         'name': 'punctuation.section.set.end.clojure'
     'name': 'meta.set.clojure'
@@ -243,11 +243,11 @@
     'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+        'name': 'punctuation.section.expression.end.trailing.clojure'
       '2':
         'name': 'meta.after-expression.clojure'
       '3':
-        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+        'name': 'punctuation.section.expression.end.trailing.clojure'
       '4':
         'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.expression.clojure'
@@ -358,7 +358,7 @@
     'end': '(\\](?=[\\}\\]\\)\\s]*(?:;|$)))|(\\])'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.vector.end.clojure.paren-trail'
+        'name': 'punctuation.section.vector.end.trailing.clojure'
       '2':
         'name': 'punctuation.section.vector.end.clojure'
     'name': 'meta.vector.clojure'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -139,9 +139,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.map.begin.clojure'
-    'end': '(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.map.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.map.end.clojure'
     'name': 'meta.map.clojure'
     'patterns': [
@@ -156,9 +158,11 @@
         'beginCaptures':
           '1':
             'name': 'punctuation.section.metadata.map.begin.clojure'
-        'end': '(\\})'
+        'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
         'endCaptures':
           '1':
+            'name': 'punctuation.section.metadata.map.end.clojure.paren-trail'
+          '2':
             'name': 'punctuation.section.metadata.map.end.clojure'
         'name': 'meta.metadata.map.clojure'
         'patterns': [
@@ -186,12 +190,16 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure'
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
       '2':
         'name': 'meta.after-expression.clojure'
+      '3':
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+      '4':
+        'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.quoted-expression.clojure'
     'patterns': [
       {
@@ -215,9 +223,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.set.begin.clojure'
-    'end': '(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.set.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.set.end.clojure'
     'name': 'meta.set.clojure'
     'patterns': [
@@ -230,12 +240,16 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure'
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
       '2':
         'name': 'meta.after-expression.clojure'
+      '3':
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+      '4':
+        'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.expression.clojure'
     'patterns': [
       {
@@ -341,9 +355,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.vector.begin.clojure'
-    'end': '(\\])'
+    'end': '(\\](?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\])'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.vector.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.vector.end.clojure'
     'name': 'meta.vector.clojure'
     'patterns': [

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -139,7 +139,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.map.begin.clojure'
-    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
     'endCaptures':
       '1':
         'name': 'punctuation.section.map.end.clojure.paren-trail'
@@ -158,7 +158,7 @@
         'beginCaptures':
           '1':
             'name': 'punctuation.section.metadata.map.begin.clojure'
-        'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
+        'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
         'endCaptures':
           '1':
             'name': 'punctuation.section.metadata.map.end.clojure.paren-trail'
@@ -190,7 +190,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.clojure.paren-trail'
@@ -223,7 +223,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.set.begin.clojure'
-    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\})'
     'endCaptures':
       '1':
         'name': 'punctuation.section.set.end.clojure.paren-trail'
@@ -240,7 +240,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.clojure.paren-trail'
@@ -355,7 +355,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.vector.begin.clojure'
-    'end': '(\\](?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\])'
+    'end': '(\\](?=[\\}\\]\\)\\s]*(?:;|$)))|(\\])'
     'endCaptures':
       '1':
         'name': 'punctuation.section.vector.end.clojure.paren-trail'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -22,7 +22,7 @@ describe "Clojure grammar", ->
     expect(tokens[5]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]
     expect(tokens[6]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure"]
     expect(tokens[7]).toEqual value: "baz", scopes: ["source.clojure", "meta.expression.clojure", "meta.symbol.clojure"]
-    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]
+    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.trailing.clojure"]
 
   it "tokenizes maps used as functions", ->
     {tokens} = grammar.tokenizeLine "({:foo bar} :foo)"
@@ -34,4 +34,4 @@ describe "Clojure grammar", ->
     expect(tokens[5]).toEqual value: "}", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "punctuation.section.map.end.clojure"]
     expect(tokens[6]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure"]
     expect(tokens[7]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "constant.keyword.clojure"]
-    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]
+    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.trailing.clojure"]


### PR DESCRIPTION
This PR adds a `.paren-trail` class to end-of-line (EOL) close-parens without interfering with existing rules.  This is to allow users to highlight parentheses inferred by [Parinfer] in [atom-parinfer].

gif showing Before and After .paren-trail { opacity: 0.3; }:

![gif](https://camo.githubusercontent.com/2332a432c103ff253a87f676b540309f804b0d0f/687474703a2f2f692e696d6775722e636f6d2f674c6c573766422e676966)

[Parinfer]:http://shaunlebron.github.io/parinfer
[atom-parinfer]:https://github.com/oakmac/atom-parinfer

Further discussion here: https://github.com/oakmac/atom-parinfer/issues/26

Let me know if this is appropriate for merging, or if there is alternate way to keep this separate from the clojure grammar.  Thanks