### PR TITLE
Fix tokenization of sexp and map nested at beginning of another sexp

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -274,7 +274,13 @@
         'include': '#vector'
       }
       {
-        'match': '(?<=\\()([^\\(\\{]+?)(?=\\s|\\))'
+        'include': '#map'
+      }
+      {
+        'include': '#sexp'
+      }
+      {
+        'match': '(?<=\\()(.+?)(?=\\s|\\))'
         'captures':
           '1':
             'name': 'entity.name.function.clojure'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -274,7 +274,7 @@
         'include': '#vector'
       }
       {
-        'match': '(?<=\\()(.+?)(?=\\s|\\))'
+        'match': '(?<=\\()([^\\(\\{]+?)(?=\\s|\\))'
         'captures':
           '1':
             'name': 'entity.name.function.clojure'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -11,3 +11,27 @@ describe "Clojure grammar", ->
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.clojure"
+
+  it "tokenizes functions in nested sexp", ->
+    {tokens} = grammar.tokenizeLine "((foo bar) baz)"
+    expect(tokens[0]).toEqual value: "(", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.begin.clojure"]
+    expect(tokens[1]).toEqual value: "(", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure", "punctuation.section.expression.begin.clojure"]
+    expect(tokens[2]).toEqual value: "foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure", "entity.name.function.clojure"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure"]
+    expect(tokens[4]).toEqual value: "bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure", "meta.symbol.clojure"]
+    expect(tokens[5]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]
+    expect(tokens[6]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure"]
+    expect(tokens[7]).toEqual value: "baz", scopes: ["source.clojure", "meta.expression.clojure", "meta.symbol.clojure"]
+    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]
+
+  it "tokenizes maps used as functions", ->
+    {tokens} = grammar.tokenizeLine "({:foo bar} :foo)"
+    expect(tokens[0]).toEqual value: "(", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.begin.clojure"]
+    expect(tokens[1]).toEqual value: "{", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "punctuation.section.map.begin.clojure"]
+    expect(tokens[2]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "constant.keyword.clojure"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure"]
+    expect(tokens[4]).toEqual value: "bar", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "meta.symbol.clojure"]
+    expect(tokens[5]).toEqual value: "}", scopes: ["source.clojure", "meta.expression.clojure", "meta.map.clojure", "punctuation.section.map.end.clojure"]
+    expect(tokens[6]).toEqual value: " ", scopes: ["source.clojure", "meta.expression.clojure"]
+    expect(tokens[7]).toEqual value: ":foo", scopes: ["source.clojure", "meta.expression.clojure", "constant.keyword.clojure"]
+    expect(tokens[8]).toEqual value: ")", scopes: ["source.clojure", "meta.expression.clojure", "punctuation.section.expression.end.clojure"]


### PR DESCRIPTION
I'm new to Clojure, but something that jumped out at me while learning in Atom was parentheses being colored as function characters if they immediately followed another parenthesis. As someone else mentioned in #35, this also happens when maps are used as functions.

I've made a small tweak to the `entity.name.function.clojure` match to exclude ( and { as function characters. I've included screenshots below of the syntax highlighting before and after my change.

**Before**
![before](https://cloud.githubusercontent.com/assets/1648928/13515140/e5a61230-e17c-11e5-8477-c63938fd99ee.png)

**After**
![after](https://cloud.githubusercontent.com/assets/1648928/13515155/fe665604-e17c-11e5-8bc3-743f200de87a.png)

