### PR TITLE
Fixed #45: Changed regular expression to match a comment to ignore semicolons that are escaped characters.

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -69,7 +69,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.clojure'
-    'match': '(;).*$\\n?'
+    'match': '(?:(?<=[^\\\\])(;).*$\\n?)|(?:^(;).*$\\n?)'
     'name': 'comment.line.semicolon.clojure'
   'constants':
     'patterns': [

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -69,7 +69,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.clojure'
-    'match': '(?:(?<=[^\\\\])(;).*$\\n?)|(?:^(;).*$\\n?)'
+    'match': '((?<=[^\\\\]);|^;).*$\\n?'
     'name': 'comment.line.semicolon.clojure'
   'constants':
     'patterns': [

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -17,6 +17,11 @@ describe "Clojure grammar", ->
     expect(tokens[0]).toEqual value: ";", scopes: ["source.clojure", "comment.line.semicolon.clojure", "punctuation.definition.comment.clojure"]
     expect(tokens[1]).toEqual value: " clojure", scopes: ["source.clojure", "comment.line.semicolon.clojure"]
 
+  it "doesn't treat semicolon characters as comments", ->
+    {tokens} = grammar.tokenizeLine "\\; clojure"
+    expect(tokens[0]).toEqual value: "\\; ", scopes: ["source.clojure"]
+    expect(tokens[1]).toEqual value: "clojure", scopes: ["source.clojure", "meta.symbol.clojure"]
+
   it "tokenizes shebang comments", ->
     {tokens} = grammar.tokenizeLine "#!/usr/bin/env clojure"
     expect(tokens[0]).toEqual value: "#!", scopes: ["source.clojure", "comment.line.semicolon.clojure", "punctuation.definition.comment.shebang.clojure"]


### PR DESCRIPTION
I changed the regular expression to the following

```
(?:(?<=[^\\])(;).*$\\n?)|(?:^(;).*$\\n?)
```

It's doing a look behind to see if the previous character isn't a \ or it's accepting semicolons that are at the beginning of the line. 

This shows the difference after the patch.

<img width="523" alt="sample_clj_ __users_jason__atom_packages_language-clojure" src="https://cloud.githubusercontent.com/assets/192983/16603147/e9397dd4-42e7-11e6-958b-acfd22889480.png">
