### PR TITLE
Added hlisp, org-mode extensions.

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -2,13 +2,13 @@
 'fileTypes': [
   'boot'
   'clj'
+  'clj.hl'
   'cljc'
   'cljs'
+  'cljs.hl'
   'cljx'
   'clojure'
   'edn'
-  'clj.hl'
-  'cljs.hl'
   'org'
 ]
 'foldingStartMarker': '\\(\\s*$'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -7,6 +7,9 @@
   'cljx'
   'clojure'
   'edn'
+  'clj.hl'
+  'cljs.hl'
+  'org'
 ]
 'foldingStartMarker': '\\(\\s*$'
 'foldingStopMarker': '^\\s*\\)'


### PR DESCRIPTION
Just added support for hlisp (ie-> https://github.com/hoplon/brew/tree/master/src/hoplon) and org-mode (ie)-> https://github.com/thi-ng/geom/tree/master/geom-core/src).  Org-mode might present some conflicts if other instances of org-mode are used, but those are largely emacs-based, so probably outside of Atom's usage-cases anyways.