### PR TITLE
Turn `autoIndentOnPaste` off to prevent indent on pasted code

### DIFF
--- a/settings/language-clojure.cson
+++ b/settings/language-clojure.cson
@@ -1,3 +1,4 @@
 '.source.clojure':
   'editor':
+    'autoIndentOnPaste': false
     'commentStart': '; '


### PR DESCRIPTION
To fix #34. I'll disable `autoIndentOnPaste` for now.

Thanks.