### PR TITLE
Fix misclassification of spec-file on GitHub

### DIFF
--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -340,3 +340,5 @@ describe "Clojure grammar", ->
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    # -*- coffee -*- # See atom/language-html#138

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -337,8 +337,7 @@ describe "Clojure grammar", ->
         # vim:noexpandtab sts:4 ft:clojure ts:4
         # vim:noexpandtab titlestring=hi\\|there\\ ft=clojure ts=4
         # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=clojure ts=4
+        # vim:ft=coffee ft2=clojure
       """
       for line in invalid.split /\n/
         expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
-
-    # -*- coffee -*- # See atom/language-html#138


### PR DESCRIPTION
See: atom/language-html#138

<img src="https://cloud.githubusercontent.com/assets/2346707/18976566/0ebe61bc-86f6-11e6-8bb9-c040b4304307.png" width="640" alt="Well... oops?" />
