### PR TITLE
Fix tokenization of escaped characters in regexes

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -238,8 +238,8 @@
       }
     ]
   'regexp_escaped_char':
-    'match': '\\\\'
-    'name': 'constant.character.escape.backslash.clojure'
+    'match': '\\\\.'
+    'name': 'constant.character.escape.clojure'
   'set':
     'begin': '(\\#\\{)'
     'beginCaptures':

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -41,12 +41,17 @@ describe "Clojure grammar", ->
     expect(tokens[2]).toEqual value: '"', scopes: ["source.clojure", "string.regexp.clojure"]
 
   it "tokenizes backslash escape character in regexes", ->
-    {tokens} = grammar.tokenizeLine '#"\\" "/"'
-    expect(tokens[1]).toEqual value: "\\", scopes: ['source.clojure', 'string.regexp.clojure', 'constant.character.escape.backslash.clojure']
+    {tokens} = grammar.tokenizeLine '#"\\\\" "/"'
+    expect(tokens[1]).toEqual value: "\\\\", scopes: ['source.clojure', 'string.regexp.clojure', 'constant.character.escape.clojure']
     expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure']
     expect(tokens[4]).toEqual value: '"', scopes: ['source.clojure', 'string.quoted.double.clojure', 'punctuation.definition.string.begin.clojure']
     expect(tokens[5]).toEqual value: "/", scopes: ['source.clojure', 'string.quoted.double.clojure']
     expect(tokens[6]).toEqual value: '"', scopes: ['source.clojure', 'string.quoted.double.clojure', 'punctuation.definition.string.end.clojure']
+
+  it "tokenizes escaped double quote in regexes", ->
+    {tokens} = grammar.tokenizeLine '#"\\""'
+    expect(tokens[1]).toEqual value: '\\"', scopes: ['source.clojure', 'string.regexp.clojure', 'constant.character.escape.clojure']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure']
 
   it "tokenizes numerics", ->
     numbers =


### PR DESCRIPTION
The issue with escaped characters in regular expressions was first reported in #11 and partially fixed in #14. It was reported a second time in #41 and partially "fixed" in #50. The second fix is a regression of the first fix:
- [Example in Ligthshow after #14](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fatom%2Flanguage-clojure%2Fblob%2Faefe0fd40ad124f231250e5793d5bb3f807ef843%2Fgrammars%2Fclojure.cson&grammar_text=&code_source=from-text&code_url=https%3A%2F%2Fgithub.com%2FMikechaos%2FPragmatic-Programmer-Exercices%2Fblob%2Fmaster%2FEx6-BNF-Interpreter%2Fex-6-draft.clj%23L81&code=%28def+terminal-token-re+%23%22%5B%5CS%5C%22%5D%2B%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29%0D%0A%28clojure.string%2Freplace+%22foo%5C%5Cbar%22+%23%22%5C%5C%22+%22%2F%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29)
- [Example in Lightshow after #50](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fatom%2Flanguage-clojure%2Fblob%2F81679d8226aaadb64129a53c8c43323f4e28ebb5%2Fgrammars%2Fclojure.cson&grammar_text=&code_source=from-text&code_url=https%3A%2F%2Fgithub.com%2FMikechaos%2FPragmatic-Programmer-Exercices%2Fblob%2Fmaster%2FEx6-BNF-Interpreter%2Fex-6-draft.clj%23L81&code=%28def+terminal-token-re+%23%22%5B%5CS%5C%22%5D%2B%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29%0D%0A%28clojure.string%2Freplace+%22foo%5C%5Cbar%22+%23%22%5C%5C%22+%22%2F%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29)
- [Example in Lightshow with this pull request](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2Flanguage-clojure%2Fblob%2F4bf691f5c7873bf5677bbaf2bbbc3d567e736460%2Fgrammars%2Fclojure.cson&grammar_text=&code_source=from-text&code_url=https%3A%2F%2Fgithub.com%2FMikechaos%2FPragmatic-Programmer-Exercices%2Fblob%2Fmaster%2FEx6-BNF-Interpreter%2Fex-6-draft.clj%23L81&code=%28def+terminal-token-re+%23%22%5B%5CS%5C%22%5D%2B%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29%0D%0A%28clojure.string%2Freplace+%22foo%5C%5Cbar%22+%23%22%5C%5C%22+%22%2F%22%29%0D%0A%28def+token-re+%28re-pattern+%28str%2Fjoin+%22%7C%22+%5Bterm-re+terminal-token-re+space-re%5D%29%29%29)

This pull request fixes the grammar as well as the test for #41 and adds a new test for #11.

The regression was initially reported by @Mikechaos at github/linguist#3260.