### PR TITLE
Any form of [namespace/]def* to define entity.global.clojure

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -277,8 +277,8 @@
     'name': 'meta.expression.clojure'
     'patterns': [
       {
-        # everything that starts with def* or namespace/def*
-        'begin': '(?<=\\()(ns|def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*|[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*/def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)\\s+'
+        # ns, declare and everything that starts with def* or namespace/def*
+        'begin': '(?<=\\()(ns|declare|def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*|[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*/def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)\\s+'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -277,7 +277,8 @@
     'name': 'meta.expression.clojure'
     'patterns': [
       {
-        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+'
+        # everything that starts with def* or namespace/def*
+        'begin': '(?<=\\()(ns|def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*|[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*/def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)\\s+'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -278,7 +278,7 @@
     'patterns': [
       {
         # ns, declare and everything that starts with def* or namespace/def*
-        'begin': '(?<=\\()(ns|declare|def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*|[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*/def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)\\s+'
+        'begin': '(?<=\\()(ns|declare|def[\\w\\d._:+=><!?*-]*|[\\w._:+=><!?*-][\\w\\d._:+=><!?*-]*/def[\\w\\d._:+=><!?*-]*)\\s+'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -109,9 +109,12 @@ describe "Clojure grammar", ->
       expect(tokens[1]).toEqual value: keyfn, scopes: ["source.clojure", "meta.expression.clojure", "storage.control.clojure"]
 
   it "tokenizes global definitions", ->
-    {tokens} = grammar.tokenizeLine "(def foo 'bar)"
-    expect(tokens[1]).toEqual value: "def", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "keyword.control.clojure"]
-    expect(tokens[3]).toEqual value: "foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "entity.global.clojure"]
+    macros = ["ns", "declare", "def", "defn", "defn-", "defroutes", "compojure/defroutes", "rum.core/defc123-", "some.nested-ns/def-nested->symbol!?*", "def+!.?abc8:<>", "ns/def+!.?abc8:<>"]
+
+    for macro in macros
+      {tokens} = grammar.tokenizeLine "(#{macro} foo 'bar)"
+      expect(tokens[1]).toEqual value: macro, scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "keyword.control.clojure"]
+      expect(tokens[3]).toEqual value: "foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "entity.global.clojure"]
 
   it "tokenizes dynamic variables", ->
     mutables = ["*ns*", "*foo-bar*"]


### PR DESCRIPTION
### Description of the Change

It’s a convention in Clojure to use macros whose name starts with `def` to define something. Libraries often define their own custom macros for this:

- `defroutes` (Compojure)
- `deftemplate`, `defsnippet` (Enlive)
- `defc`, `defcs`, `defcc` (Rum)
- `defnav`, `defcollector`, `defprotocolpath` (Specter)
- `defproject` (lein)
- `clojure.spec/def` (clojure.spec)
- `schema.core/defn`, `schema.core/defrecord` (Prismatic Schema)
- etc

Another problem is that many people like to use def* macros from external libraries with namespace aliases (`enlive/deftemplate`, `rum/defc`). Sometimes you just have to, as in Clojure Spec or Prismatic Schema whose names conflict with clojure.core equivalents.

This PR adds regular expression that treats all forms whose name starts with `def` (with optional namespace) similarly.

### Alternate Designs

The old way (before change) was whitelisting only def macros from clojure.core. It wasn’t working because it will detect standard vars and functions but will fail to detect custom `def*`-like macros.

### Benefits

Detect and highlight more entities from custom def-like macros.

### Possible Drawbacks

Mistakenly detect as entity definition a macro which isn’t entity definition but whose name starts with `def` (highly unlikely)

### Applicable Issues

This convention is very well established so it shouldn’t hurt anyone.

