### PR TITLE
Capture regexp begin/end as punctuation in Clojure syntax

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -231,11 +231,11 @@
       }
     ]
   'regexp':
-    'begin': '#\\"'
+    'begin': '#"'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.regexp.begin.clojure'
-    'end': '\\"'
+    'end': '"'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.regexp.end.clojure'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -232,7 +232,13 @@
     ]
   'regexp':
     'begin': '#\\"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.regexp.begin.clojure'
     'end': '\\"'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.regexp.end.clojure'
     'name': 'string.regexp.clojure'
     'patterns': [
       {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -36,22 +36,24 @@ describe "Clojure grammar", ->
 
   it "tokenizes regexes", ->
     {tokens} = grammar.tokenizeLine '#"foo"'
-    expect(tokens[0]).toEqual value: '#"', scopes: ["source.clojure", "string.regexp.clojure"]
+    expect(tokens[0]).toEqual value: '#"', scopes: ["source.clojure", "string.regexp.clojure", "punctuation.definition.regexp.begin.clojure"]
     expect(tokens[1]).toEqual value: 'foo', scopes: ["source.clojure", "string.regexp.clojure"]
-    expect(tokens[2]).toEqual value: '"', scopes: ["source.clojure", "string.regexp.clojure"]
+    expect(tokens[2]).toEqual value: '"', scopes: ["source.clojure", "string.regexp.clojure", "punctuation.definition.regexp.end.clojure"]
 
   it "tokenizes backslash escape character in regexes", ->
     {tokens} = grammar.tokenizeLine '#"\\\\" "/"'
+    expect(tokens[0]).toEqual value: '#"', scopes: ["source.clojure", "string.regexp.clojure", "punctuation.definition.regexp.begin.clojure"]
     expect(tokens[1]).toEqual value: "\\\\", scopes: ['source.clojure', 'string.regexp.clojure', 'constant.character.escape.clojure']
-    expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure', "punctuation.definition.regexp.end.clojure"]
     expect(tokens[4]).toEqual value: '"', scopes: ['source.clojure', 'string.quoted.double.clojure', 'punctuation.definition.string.begin.clojure']
     expect(tokens[5]).toEqual value: "/", scopes: ['source.clojure', 'string.quoted.double.clojure']
     expect(tokens[6]).toEqual value: '"', scopes: ['source.clojure', 'string.quoted.double.clojure', 'punctuation.definition.string.end.clojure']
 
   it "tokenizes escaped double quote in regexes", ->
     {tokens} = grammar.tokenizeLine '#"\\""'
+    expect(tokens[0]).toEqual value: '#"', scopes: ["source.clojure", "string.regexp.clojure", "punctuation.definition.regexp.begin.clojure"]
     expect(tokens[1]).toEqual value: '\\"', scopes: ['source.clojure', 'string.regexp.clojure', 'constant.character.escape.clojure']
-    expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure']
+    expect(tokens[2]).toEqual value: '"', scopes: ['source.clojure', 'string.regexp.clojure', "punctuation.definition.regexp.end.clojure"]
 
   it "tokenizes numerics", ->
     numbers =


### PR DESCRIPTION
### Description of the Change

When highlighting regexp, starting `#"` and ending `"` should be of class `punctuation`. That is done e.g. for strings but was forgotten for regexpes

### Alternate Designs

This is a very simple change. I believe there’s only one way to do it.

### Benefits

Regexpes are highlighted the same way everything else is (e.g. strings, vectors, maps).

### Possible Drawbacks

None

### Applicable Issues

None
