### PR TITLE
Don't tokenize trailing whitespace as invalid

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -82,9 +82,6 @@
   {
     'include': '#symbol'
   }
-  {
-    'include': '#whitespace'
-  }
 ]
 'repository':
   'comment':
@@ -214,15 +211,13 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
+    'end': '(\\))$|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.trailing.clojure'
       '2':
-        'name': 'meta.after-expression.clojure'
-      '3':
         'name': 'punctuation.section.expression.end.trailing.clojure'
-      '4':
+      '3':
         'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.quoted-expression.clojure'
     'patterns': [
@@ -270,15 +265,13 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
+    'end': '(\\))$|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.trailing.clojure'
       '2':
-        'name': 'meta.after-expression.clojure'
-      '3':
         'name': 'punctuation.section.expression.end.trailing.clojure'
-      '4':
+      '3':
         'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.expression.clojure'
     'patterns': [
@@ -403,6 +396,3 @@
         'include': '$self'
       }
     ]
-  'whitespace':
-    'match': '\\s+$'
-    'name': 'invalid.trailing-whitespace'

--- a/spec/clojure-spec.coffee
+++ b/spec/clojure-spec.coffee
@@ -155,15 +155,11 @@ describe "Clojure grammar", ->
     expect(tokens[1]).toEqual value: "/", scopes: ["source.clojure"]
     expect(tokens[2]).toEqual value: "bar", scopes: ["source.clojure", "meta.symbol.clojure"]
 
-  it "tokenizes trailing whitespace", ->
-    {tokens} = grammar.tokenizeLine "   \n"
-    expect(tokens[0]).toEqual value: "   \n", scopes: ["source.clojure", "invalid.trailing-whitespace"]
-
   testMetaSection = (metaScope, puncScope, startsWith, endsWith) ->
     # Entire expression on one line.
     {tokens} = grammar.tokenizeLine "#{startsWith}foo, bar#{endsWith}"
 
-    [start, mid..., end, after] = tokens
+    [start, mid..., end] = tokens
 
     expect(start).toEqual value: startsWith, scopes: ["source.clojure", "meta.#{metaScope}.clojure", "punctuation.section.#{puncScope}.begin.clojure"]
     expect(end).toEqual value: endsWith, scopes: ["source.clojure", "meta.#{metaScope}.clojure", "punctuation.section.#{puncScope}.end.trailing.clojure"]
@@ -181,7 +177,7 @@ describe "Clojure grammar", ->
     for token in mid
       expect(token.scopes.slice(0, 2)).toEqual ["source.clojure", "meta.#{metaScope}.clojure"]
 
-    [mid..., end, after] = tokens[1]
+    [mid..., end] = tokens[1]
 
     expect(end).toEqual value: endsWith, scopes: ["source.clojure", "meta.#{metaScope}.clojure", "punctuation.section.#{puncScope}.end.trailing.clojure"]
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Wow, this was harder than expected.  :fire: the patterns that were tokenizing trailing whitespace (even EOLs!) as invalid, and remove some odd `after-expression` scopes.

### Alternate Designs

None.

### Benefits

Leaves it up to the developer to decide whether or not trailing whitespace is bad.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #51