### PR TITLE
Do not tokenize escaped semicolons as comments

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -86,7 +86,7 @@
 'repository':
   'comment':
     # NOTE: This must be kept as a begin/end match for language-todo to work
-    'begin': ';'
+    'begin': '(?<!\\\\);'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.clojure'

--- a/spec/clojure-spec.coffee
+++ b/spec/clojure-spec.coffee
@@ -12,10 +12,15 @@ describe "Clojure grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.clojure"
 
-  it "tokenizes semi-colon comments", ->
+  it "tokenizes semicolon comments", ->
     {tokens} = grammar.tokenizeLine "; clojure"
     expect(tokens[0]).toEqual value: ";", scopes: ["source.clojure", "comment.line.semicolon.clojure", "punctuation.definition.comment.clojure"]
     expect(tokens[1]).toEqual value: " clojure", scopes: ["source.clojure", "comment.line.semicolon.clojure"]
+
+  it "does not tokenize escaped semicolons as comments", ->
+    {tokens} = grammar.tokenizeLine "\\; clojure"
+    expect(tokens[0]).toEqual value: "\\; ", scopes: ["source.clojure"]
+    expect(tokens[1]).toEqual value: "clojure", scopes: ["source.clojure", "meta.symbol.clojure"]
 
   it "tokenizes shebang comments", ->
     {tokens} = grammar.tokenizeLine "#!/usr/bin/env clojure"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Clojure allows you to escape semicolons to avoid it being parsed as a comment.  Respect that.

### Alternate Designs

None.

### Benefits

Escaped semicolons `\;` will no longer be tokenized as comments.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #45
Supersedes and closes #46