### PR TITLE
Add support for .joke and .joker files

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -10,6 +10,8 @@
   'clojure'
   'edn'
   'org'
+  'joke'
+  'joker'
 ]
 'foldingStartMarker': '\\(\\s*$'
 'foldingStopMarker': '^\\s*\\)'


### PR DESCRIPTION
I believe this is what needs to be changed to support the [Joker](https://github.com/candid82/joker) variant of Clojure (including the `.joker` file used for lint configuration).