### PR TITLE
Sensible defaults for non-word-characters and bracket autocompletion

### DIFF
--- a/settings/language-clojure.cson
+++ b/settings/language-clojure.cson
@@ -1,3 +1,11 @@
 '.source.clojure':
-  'editor':
-    'commentStart': '; '
+  editor:
+    commentStart: '; '
+    nonWordCharacters: '\()"\',;~@#%^[]{}`'
+  'bracket-matcher':
+    autocompleteCharacters: [
+      "()"
+      "[]"
+      "{}"
+      "\"\""
+    ]


### PR DESCRIPTION
### Description of the Change

* The language specific non-word-characters where added to reflect allowed characters in clojure code
* The bracket matcher default settings were changed to reflect the structure of cloojure code

### Alternate Designs

none

### Benefits

* Easier idiomatic clojure development experience
* More accurate suggestions from the auto completion

### Possible Drawbacks

none

### Applicable Issues

For some reasons some of these changes do not appear to work.
I am quite sure I added the settings correctly.
It *does* now suggest identifiers containing `-` and `_` but fails to suggest identifiers containting `>` and `<` for instance.
Similarly it does still auto-close `'`.
