### PR TITLE
Syntax improvements for defs and symbols

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -155,7 +155,7 @@
       }
     ]
   'dynamic-variables':
-    'match': '\\*[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\d]+\\*'
+    'match': '\\*[0-9#\'A-Z_a-z!$%&+\\-.:<=>?|]+\\*'
     'name': 'meta.symbol.dynamic.clojure'
   'map':
     'begin': '(\\{)'
@@ -279,7 +279,7 @@
     'patterns': [
       {
         # ns, declare and everything that starts with def* or namespace/def*
-        'begin': '(?<=\\()(ns|declare|def[\\w\\d._:+=><!?*-]*|[\\w._:+=><!?*-][\\w\\d._:+=><!?*-]*/def[\\w\\d._:+=><!?*-]*)\\s+'
+        'begin': '(?<=\\()(ns|declare|def[0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*|[A-Z_a-z!$%&+\\-.:<=>?|*][0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*/def[0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*)\\s+'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'
@@ -292,7 +292,7 @@
           {
             # recognizing a symbol as being defined here
             # copied and pasted from #symbol, screw it
-            'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)'
+            'match': '([A-Z_a-z!$%&+\\-.:<=>?|*][0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*)'
             'name': 'meta.definition.global.clojure entity.name.global.clojure'
           }
           { # dynamic variables are rendered diferently
@@ -364,7 +364,7 @@
     'patterns': [
       { # copied from #symbol, plus a / at the end. Matches the "app/" part of
         # "app/*config*"
-        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)/'
+        'match': '([A-Z_a-z!$%&+\\-.:<=>?|*][0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*)/'
         'captures':
           '1':
             'name': 'meta.symbol.namespace.clojure'
@@ -373,12 +373,12 @@
   'symbol':
     'patterns': [
       {
-        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)' 
+        'match': '([A-Z_a-z!$%&+\\-.:<=>?|*][0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*]*)'
         'name': 'meta.symbol.clojure'
       }
     ]
   'var':
-    'match': '(?<=(\\s|\\(|\\[|\\{)\\#)\'[a-zA-Z0-9\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}))'
+    'match': '(?<=(\\s|\\(|\\[|\\{)\\#)\'[A-Z_a-z!$%&+\\-.:<=>?|*][0-9#\'A-Z_a-z!$%&+\\-.:<=>?|*/]*(?=(\\s|\\)|\\]|\\}))'
     'name': 'meta.var.clojure'
   'vector':
     'begin': '(\\[)'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -292,7 +292,7 @@
           {
             # recognizing a symbol as being defined here
             # copied and pasted from #symbol, screw it
-            'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
+            'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)'
             'name': 'meta.definition.global.clojure entity.name.global.clojure'
           }
           { # dynamic variables are rendered diferently
@@ -364,7 +364,7 @@
     'patterns': [
       { # copied from #symbol, plus a / at the end. Matches the "app/" part of
         # "app/*config*"
-        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)/'
+        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)/'
         'captures':
           '1':
             'name': 'meta.symbol.namespace.clojure'
@@ -373,7 +373,7 @@
   'symbol':
     'patterns': [
       {
-        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
+        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]*)' 
         'name': 'meta.symbol.clojure'
       }
     ]

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -289,14 +289,14 @@
             # there may be some metadata before an actual definition
             'include': '#metadata'
           }
-          { # dynamic variables are rendered diferently
-            'include': '#dynamic-variables'
-          }
           {
             # recognizing a symbol as being defined here
             # copied and pasted from #symbol, screw it
             'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
             'name': 'meta.definition.global.clojure entity.name.global.clojure'
+          }
+          { # dynamic variables are rendered diferently
+            'include': '#dynamic-variables'
           }
           {
             'include': '$self'

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -284,7 +284,6 @@
           '1':
             'name': 'keyword.control.clojure'
         'end': '(?=\\))'
-        'name': 'meta.definition.global.clojure'
         'patterns': [
           {
             # there may be some metadata before an actual definition
@@ -297,7 +296,7 @@
             # recognizing a symbol as being defined here
             # copied and pasted from #symbol, screw it
             'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
-            'name': 'entity.global.clojure'
+            'name': 'meta.definition.global.clojure entity.name.global.clojure'
           }
           {
             'include': '$self'

--- a/spec/clojure-spec.coffee
+++ b/spec/clojure-spec.coffee
@@ -117,14 +117,16 @@ describe "Clojure grammar", ->
 
   it "tokenizes global definitions", ->
     macros = ["ns", "declare", "def", "defn", "defn-", "defroutes", "compojure/defroutes", "rum.core/defc123-", "some.nested-ns/def-nested->symbol!?*", "def+!.?abc8:<>", "ns/def+!.?abc8:<>"]
+    symbols = ["foo", "f", "f'", "*f*"]
 
     for macro in macros
-      {tokens} = grammar.tokenizeLine "(#{macro} foo 'bar)"
-      expect(tokens[1]).toEqual value: macro, scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "keyword.control.clojure"]
-      expect(tokens[3]).toEqual value: "foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure", "entity.global.clojure"]
+      for symbol in symbols
+        {tokens} = grammar.tokenizeLine "(#{macro} #{symbol} 'bar)"
+        expect(tokens[1]).toEqual value: macro, scopes: ["source.clojure", "meta.expression.clojure", "keyword.control.clojure"]
+        expect(tokens[3]).toEqual value: symbol, scopes: ["source.clojure", "meta.expression.clojure", "meta.definition.global.clojure entity.name.global.clojure"]
 
   it "tokenizes dynamic variables", ->
-    mutables = ["*ns*", "*foo-bar*"]
+    mutables = ["*ns*", "*foo-bar*", "*1#*"]
 
     for mutable in mutables
       {tokens} = grammar.tokenizeLine mutable
@@ -155,10 +157,12 @@ describe "Clojure grammar", ->
     expect(tokens[3]).toEqual value: "'foo", scopes: ["source.clojure", "meta.expression.clojure", "meta.var.clojure"]
 
   it "tokenizes symbols", ->
-    {tokens} = grammar.tokenizeLine "foo/bar"
-    expect(tokens[0]).toEqual value: "foo", scopes: ["source.clojure", "meta.symbol.namespace.clojure"]
-    expect(tokens[1]).toEqual value: "/", scopes: ["source.clojure"]
-    expect(tokens[2]).toEqual value: "bar", scopes: ["source.clojure", "meta.symbol.clojure"]
+    for ns in ["foo", "f", "f1", "ns.ns"]
+      for symbol in ["bar", "b", "b2", "b'", "bar.bar"]
+        {tokens} = grammar.tokenizeLine "#{ns}/#{symbol}"
+        expect(tokens[0]).toEqual value: ns, scopes: ["source.clojure", "meta.symbol.namespace.clojure"]
+        expect(tokens[1]).toEqual value: "/", scopes: ["source.clojure"]
+        expect(tokens[2]).toEqual value: symbol, scopes: ["source.clojure", "meta.symbol.clojure"]
 
   testMetaSection = (metaScope, puncScope, startsWith, endsWith) ->
     # Entire expression on one line.


### PR DESCRIPTION
### Description of the Change

In top-level definitions like

```clojure
(defn f [] (+ 1 2))
```
we shouldn’t mark the whole expression as `"meta.definition.global.clojure"`. Instead, we should mark only `f` (function name) as `"entity.name.global.clojure meta.definition.global.clojure"`. This is similar to how other syntaxes do it, e.g. JavaScript and Python.

In addition to that, this PR contains a couple of fixes to existing regexps:

- Recognize single-char symbols
- Symbols can’t start with `[0-9#']`
- Symbols can contain `[#$%&'|]`
- When defining dynamic var `(def *var* ...)`, capture `*var*` as `"entity.name.global"` as well 

### Alternate Designs

Not applicable

### Benefits

- Better syntax highlighting
- Syntax highlighting working closer to other languages

### Possible Drawbacks

Existing themes that were designed specifically with Clojure syntax in mind might break (I doubt ones exist, though)

### Applicable Issues

Not applicable