### PR TITLE
Recognize hyphens as part of words for autocomplete, but not cursor movement

### DIFF
--- a/settings/language-clojure.cson
+++ b/settings/language-clojure.cson
@@ -1,3 +1,5 @@
 '.source.clojure':
   'editor':
     'commentStart': '; '
+  'autocomplete':
+    'extraWordCharacters': '-'

--- a/settings/language-clojure.cson
+++ b/settings/language-clojure.cson
@@ -1,4 +1,3 @@
 '.source.clojure':
   'editor':
-    'nonWordCharacters': '/\\()":,.;<>~@#$%^&|=[]{}`…'
     'commentStart': '; '


### PR DESCRIPTION
🍐 'd with @maxbrunsfeld 

Previously, we removed `-` to the `editor.nonWordCharacters` setting to allow words containing dashes to continue to be completed following https://github.com/atom/autocomplete-plus/pull/886. However, this changed cursor movement behavior. This PR reverts that change and *adds* `-` to `autocomplete.extraWordCharacters` to achieve the same effect. Depends on https://github.com/atom/autocomplete-plus/pull/944.