### PR TITLE
Remove capture of "default" and minor sexp regex cleanup

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -150,7 +150,7 @@
         'name': 'storage.control.clojure'
       }
       {
-        'match': '(?<=(\\s|\\(|\\[|\\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def[a-z\\-]*))(?=(\\s|\\)|\\]|\\}))'
+        'match': '(?<=(\\s|\\(|\\[|\\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def(?!ault)[a-z\\-]*))(?=(\\s|\\)|\\]|\\}))'
         'name': 'keyword.control.clojure'
       }
     ]
@@ -278,8 +278,8 @@
     'name': 'meta.expression.clojure'
     'patterns': [
       {
-        # ns, declare and everything that starts with def* or namespace/def*
-        'begin': '(?<=\\()(ns|declare|def[\\w\\d._:+=><!?*-]*|[\\w._:+=><!?*-][\\w\\d._:+=><!?*-]*/def[\\w\\d._:+=><!?*-]*)\\s+'
+        # ns, declare and everything that starts with def* or namespace/def* (except default*)
+        'begin': '(?<=\\()(ns|declare|def(?!ault)[\\w.:+=><!?*-]*|[a-zA-Z.:+=><!?*-][\\w.:+=><!?*-]*/def(?!ault)[\\w.:+=><!?*-]*)\\s+'
         'beginCaptures':
           '1':
             'name': 'keyword.control.clojure'


### PR DESCRIPTION
### Description of the Change
Before, the keyword control pattern match would match all words starting with "def" (if surrounded by certain characters).
After, the match behaves the same, except it will not match words starting with "default" (including "defaults" "defaulting" etc.). "Default" and its derivatives are considered the only words staring with "def" that would be commonly used in code which are nearly always not definitions.
Also, the sexp regex has been updated to reflect this. While there, I noticed some bad regex (notably, confusion of \w with [a-zA-Z] (which are not the same!) .

### Alternate Designs

None

### Benefits

"default" and derivatives won't be highlighted as a def-like construct

### Possible Drawbacks

Anyone creating a macro to define something starting with "ault" would not see correct handling. This is very unlikely as there are no words in any modern language starting with "ault" except one word ("ault") in a Sursilvan dialect of Romansh, which is an adjective anyway.

### Applicable Issues

None
