### PR TITLE
Remove recursive expression matching within function names

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -327,11 +327,6 @@
         'captures':
           '1':
             'name': 'entity.name.function.clojure'
-        'patterns': [
-          {
-            'include': '$self'
-          }
-        ]
       }
       {
         'include': '$self'


### PR DESCRIPTION
⚠️ WIP ⚠️ 

#### Background

The `entity.name.function.clojure` rule matches function names: within a S-expression, it matches the entry right after the opening parenthesis. Currently, once a function name is matched, we recursively try to match for other expressions *within* the function name.

#### Problem

In GitHub.com's TextMate highlighting engine, this recursion is somehow preventing us from matching the *end* of the *outer* S-expression, leading to deeper and deeper nesting as we encounter more and more parenthesized S-expressions.

#### Drawbacks

Atom works fine with this Grammar. VSCode also works fine with [the same grammar](https://github.com/microsoft/vscode/blob/c445d5c408389bfda8af6e188474e77b2cb45af6/extensions/clojure/syntaxes/clojure.tmLanguage.json#L338-L350). This makes me thing there is a bug in our TextMate engine, but I haven't investigated deeply.

On the other hand, I don't understand why we would need to match syntactic structure *within* a function name. Maybe this is to handle namespaced symbols?

/cc @hanjos because you added this rule in #13.

/cc @jhawthorn @vmg @kivikakk 