### PR TITLE
Fix matching of numbers

### DIFF
--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -105,35 +105,35 @@
         'name': 'constant.language.boolean.clojure'
       }
       {
-        'match': '(-?\\d+/\\d+)'
+        'match': '([-+]?\\d+/\\d+)'
         'name': 'constant.numeric.ratio.clojure'
       }
       {
-        'match': '(-?\\d+[rR]\\w+)'
+        'match': '([-+]?\\d+[rR]\\w+)'
         'name': 'constant.numeric.arbitrary-radix.clojure'
       }
       {
-        'match': '(-?0[xX][0-9a-fA-F]+)'
+        'match': '([-+]?0[xX][0-9a-fA-F]+)'
         'name': 'constant.numeric.hexadecimal.clojure'
       }
       {
-        'match': '(-?0\\d+)'
+        'match': '([-+]?0\\d+)'
         'name': 'constant.numeric.octal.clojure'
       }
       {
-        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
+        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
         'name': 'constant.numeric.bigdecimal.clojure'
       }
       {
-        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?)'
+        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?)'
         'name': 'constant.numeric.double.clojure'
       }
       {
-        'match': '(-?\\d+N)'
+        'match': '([-+]?\\d+N)'
         'name': 'constant.numeric.bigint.clojure'
       }
       {
-        'match': '(-?\\d+)'
+        'match': '([-+]?\\d+)'
         'name': 'constant.numeric.long.clojure'
       }
       { # separating the pattern for reuse

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -105,35 +105,33 @@
         'name': 'constant.language.boolean.clojure'
       }
       {
+        'match': '(##(?:Inf|-Inf|NaN))'
+        'name': 'constant.numeric.symbol.clojure'
+      }
+      {
         'match': '([-+]?\\d+/\\d+)'
         'name': 'constant.numeric.ratio.clojure'
       }
       {
-        'match': '([-+]?\\d+[rR]\\w+)'
+        # Only Radixes between 2 and 36 are allowed
+        'match': '([-+]?(?:(?:3[0-6])|(?:[12]\\d)|[2-9])[rR][0-9A-Za-z]+N?)'
         'name': 'constant.numeric.arbitrary-radix.clojure'
       }
       {
-        'match': '([-+]?0[xX][0-9a-fA-F]+)'
+        'match': '([-+]?0[xX][0-9a-fA-F]+N?)'
         'name': 'constant.numeric.hexadecimal.clojure'
       }
       {
-        'match': '([-+]?0\\d+)'
+        'match': '([-+]?0[0-7]+N?)'
         'name': 'constant.numeric.octal.clojure'
       }
       {
-        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
-        'name': 'constant.numeric.bigdecimal.clojure'
-      }
-      {
-        'match': '([-+]?\\d+\\.\\d+([eE][+-]?\\d+)?)'
+        # The decimal separator is optional only when followed by e, E or M! 
+        'match': '([-+]?[0-9]+(?:(\\.|(?=[eEM]))[0-9]*([eE][-+]?[0-9]+)?)M?)'
         'name': 'constant.numeric.double.clojure'
       }
       {
-        'match': '([-+]?\\d+N)'
-        'name': 'constant.numeric.bigint.clojure'
-      }
-      {
-        'match': '([-+]?\\d+)'
+        'match': '([-+]?\\d+N?)'
         'name': 'constant.numeric.long.clojure'
       }
       { # separating the pattern for reuse

--- a/spec/clojure-spec.coffee
+++ b/spec/clojure-spec.coffee
@@ -62,14 +62,13 @@ describe "Clojure grammar", ->
 
   it "tokenizes numerics", ->
     numbers =
-      "constant.numeric.ratio.clojure": ["1/2", "123/456"]
-      "constant.numeric.arbitrary-radix.clojure": ["2R1011", "16rDEADBEEF", "56råäöÅÄÖπ"]
-      "constant.numeric.hexadecimal.clojure": ["0xDEADBEEF", "0XDEADBEEF"]
-      "constant.numeric.octal.clojure": ["0123"]
-      "constant.numeric.bigdecimal.clojure": ["123.456M"]
-      "constant.numeric.double.clojure": ["123.45", "123.45e6", "123.45E6"]
-      "constant.numeric.bigint.clojure": ["123N"]
-      "constant.numeric.long.clojure": ["123", "12321"]
+      "constant.numeric.ratio.clojure": ["1/2", "123/456", "+0/2", "-23/1"]
+      "constant.numeric.arbitrary-radix.clojure": ["2R1011", "16rDEADBEEF", "16rDEADBEEFN", "36rZebra"]
+      "constant.numeric.hexadecimal.clojure": ["0xDEADBEEF", "0XDEADBEEF", "0xDEADBEEFN", "0x0"]
+      "constant.numeric.octal.clojure": ["0123", "0123N", "00"]
+      "constant.numeric.double.clojure": ["123.45", "123.45e6", "123.45E6", "123.456M", "42.", "42.M", "42E+9M", "42E-0", "0M", "+0M", "42.E-23M"]
+      "constant.numeric.long.clojure": ["123", "12321", "123N", "+123N", "-123", "0"]
+      "constant.numeric.symbol.clojure": ["##Inf", "##-Inf", "##NaN"]
 
     for scope, nums of numbers
       for num in nums


### PR DESCRIPTION
### Description of the Change
This PR fixes several issues with number matching. (See https://github.com/atom/language-clojure/issues/89)

1. Clojure allows for an explicit `+` prefix.
2. Clojure has three symbolic Number values for +/- infinity and "Not a Number"
3. Every integer number can have the BigInt suffix `N`, that includes octals, hexadecimals and arbitrary radix
     - I merged `constant.numeric.bigint.clojure` into `constant.numeric.long.clojure` as it doesn't make any sense any more, to have it separate.
     - I also merged `constant.numeric.bigdecimal.clojure` into `constant.numeric.double.clojure` for consistency.
4. The decimal separator `.` is optional when followed by `e`, `E`, `M`
5. "Arbitrary" radix is constraint to 2-36 (digit 0-9 & a-z). Also, `\w` also matches `_` which is incorrect. 
     - One could argue, that mismatching radix/value (e.g. `2rABZ`) shouldn't be matched either, but I considered it overkill.
     - This change is debatable, because it 
6. Octal numbers can't contain `8` or `9`



It also adds a bunch of tests to check for previously missed cases. 

### Alternate Designs
I considered constraining the changes to only eliminate false-negatives. (Change 5 and 6 are only fixing false-positives)
I opted against that because a more strict highlighting is the fastest way of feedback a developer can get. 

### Benefits
More accurate highlighting of numbers. 

### Possible Drawbacks
The matching is more strict. Some false-positives aren't highlighted any more. (Although not really a drawback, it is a breaking change if someone relies on current bugs... But, how would?)

### Applicable Issues
resolves https://github.com/atom/language-clojure/issues/89
